### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+### Changed
+### Fixed
+### Removed
+### BREAKING CHANGES
+
+## [3.0.0] - 2021-01-09
+
+### Added
 - chore: Add data-provider addons recommended tags to package.json
+
 ### Changed
 - docs: Adapt docs to data-provider v3 API
 - chore(deps): Update dependencies
+
 ### Fixed
 - feat: Add force option when cleaning cache if url is changed
-### Removed
+
 ### BREAKING CHANGES
 - feat: Url now has to be defined as a property options object. Options has to be passed as first and unique argument.
 - feat: Remove v2 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- chore: Add data-provider addons recommended tags to package.json
 ### Changed
+- docs: Adapt docs to data-provider v3 API
+- chore(deps): Update dependencies
 ### Fixed
+- feat: Add force option when cleaning cache if url is changed
 ### Removed
 ### BREAKING CHANGES
+- feat: Url now has to be defined as a property options object. Options has to be passed as first and unique argument.
+- feat: Remove v2 compatibility
 
 ## [2.1.0] - 2021-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
-- feat: Add compatibility with @data-provider/core v3 arguments.
 ### Changed
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+
+## [2.1.0] - 2021-01-07
+
+### Added
+- feat: Add compatibility with @data-provider/core v3 arguments.
 
 ## [2.0.3] - 2020-12-27
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This package provides a [Data Provider][data-provider] origin for reading data f
 
 `import { Prismic } from "@data-provider/prismic"`
 
-`new Prismic(url, options)`
+`new Prismic(options)`
 * Arguments
-	* url - _`<String>`_. Prismic api url. Will be used also as provider id.
 	* options - _`<Object>`_ Apart from common Data Provider options, this addon has next custom options:
+    * url - _`<String>`_. Prismic api url.
 		* fullResponse - _`<Boolean>`_ If `true`, the full response of the Prismic api will be used as value. If `false`, only the `response.results` property will be returned, which is the default behavior.
 		* release - _`<String>`_ Prismic release to be read. This parameter will be passed as `ref` to the [prismic-javascript][prismic-javascript-url] query.
 
@@ -23,9 +23,9 @@ This package provides a [Data Provider][data-provider] origin for reading data f
 
 ### query
 
-`prismic.query(queryObject)`
+`prismic.query(queryValue)`
 * Arguments
-	* queryObject - `<Object>` containing properties:
+	* queryValue - `<Object>` containing properties:
 		* documentType - `<String>` Prismic document type to filter by. (It will be used to build a [prismic-javascript][prismic-javascript-url] query as in `PrismicJs.Predicates.at("document.type", documentType)`)
 * Returns - New queried instance having all common [Data Provider][data-provider] methods.
 
@@ -61,7 +61,8 @@ Next example will be easier to understand if you are already familiarized with t
 ```js
 import { Prismic } from "@data-provider/prismic";
 
-const prismic = new Prismic("https://foo-prismic-repository.cdn.prismic.io/api/v2", {
+const prismic = new Prismic({
+  url: "https://foo-prismic-repository.cdn.prismic.io/api/v2",
   release: "foo-release"
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/prismic",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/prismic",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,9 +1052,9 @@
       }
     },
     "@data-provider/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-X7VhA3bBVHQtMdy63mm7HLCBNUF8/jp2G8yFk0sI3ciS+wCX66WRc86Z3YADEOBlW1dsH9QUHVhK4y0nAdjOqA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-aqVRNClt+iFx3xvCB0sgkG0a3y2dthKI70p2SR9whXGX9SGUzVbTQIE4t22al37qaT23nByE3206Cd3fxXYJkg==",
       "dev": true,
       "requires": {
         "is-promise": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/prismic",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Data Provider for reading data from Prismic CMS API",
   "keywords": [
     "data-provider",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Data Provider for reading data from Prismic CMS API",
   "keywords": [
     "data-provider",
+    "data-provider-addon",
+    "data-provider-origin",
     "origin",
     "cms",
     "prismic",
@@ -30,7 +32,7 @@
     "test:unit": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary"
   },
   "peerDependencies": {
-    "@data-provider/core": ">=2.10.0"
+    "@data-provider/core": "3.x"
   },
   "dependencies": {
     "prismic-javascript": "2.1.5"
@@ -38,7 +40,7 @@
   "devDependencies": {
     "@babel/core": "7.12.3",
     "@babel/preset-env": "7.12.1",
-    "@data-provider/core": "2.10.0",
+    "@data-provider/core": "3.0.0",
     "@rollup/plugin-babel": "5.2.1",
     "@rollup/plugin-commonjs": "16.0.0",
     "@rollup/plugin-json": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/prismic",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Data Provider for reading data from Prismic CMS API",
   "keywords": [
     "data-provider",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=data-provider
 sonar.projectKey=data-provider-prismic
-sonar.projectVersion=2.1.0
+sonar.projectVersion=3.0.0
 
 sonar.sources=src,test
 sonar.exclusions=node_modules/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=data-provider
 sonar.projectKey=data-provider-prismic
-sonar.projectVersion=2.0.3
+sonar.projectVersion=2.1.0
 
 sonar.sources=src,test
 sonar.exclusions=node_modules/**

--- a/src/Prismic.js
+++ b/src/Prismic.js
@@ -20,29 +20,29 @@ const defaultConfig = {
 };
 
 export class Prismic extends Provider {
-  constructor(url, options, query) {
-    super({ id: `prismic-${url}`, ...defaultConfig, ...options, url }, query);
+  constructor(options, queryValue) {
+    super({ ...defaultConfig, ...options }, queryValue);
   }
 
   configMethod(configuration) {
     if (this._url !== configuration.url) {
       this._prismicApi = null;
       this._url = configuration.url;
-      this.cleanCache();
+      this.cleanCache({ force: true });
     }
     this._fullResponse = configuration.fullResponse;
     this._release = configuration.release;
   }
 
-  _prismicQuery(query) {
+  _prismicQuery(queryValue) {
     const prismicQuery = [];
-    if (query && query.documentType) {
-      prismicQuery.push(PrismicClient.Predicates.at("document.type", query.documentType));
+    if (queryValue && queryValue.documentType) {
+      prismicQuery.push(PrismicClient.Predicates.at("document.type", queryValue.documentType));
     }
     return prismicQuery;
   }
 
-  _prismicRequest(query) {
+  _prismicRequest(queryValue) {
     this._prismicApi =
       this._prismicApi || (this.parent && this.parent._prismicApi) || PrismicClient.api(this._url);
     return this._prismicApi.then((api) => {
@@ -50,7 +50,7 @@ export class Prismic extends Provider {
       if (this._release) {
         apiParams.ref = this._release;
       }
-      return api.query(this._prismicQuery(query), apiParams).then((response) => {
+      return api.query(this._prismicQuery(queryValue), apiParams).then((response) => {
         return Promise.resolve(this._fullResponse ? response : response.results);
       });
     });

--- a/test/Prismic.spec.js
+++ b/test/Prismic.spec.js
@@ -27,7 +27,7 @@ describe("Prismic", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     mock = new PrismicMock();
-    prismic = new Prismic(fooPrismicUrl);
+    prismic = new Prismic({ url: fooPrismicUrl });
     sandbox.spy(prismic, "cleanCache");
   });
 
@@ -60,7 +60,8 @@ describe("Prismic", () => {
 
   describe("when read is dispatched", () => {
     it("should pass release config as ref parameter to prismic client", async () => {
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         release: "foo-release",
       });
       await prismic.read();
@@ -188,7 +189,8 @@ describe("Prismic", () => {
 
     it("should override previously defined url when using providers handler even when provider has its own tag defined", async () => {
       expect.assertions(1);
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         tags: ["foo-tag"],
       });
       const FOO_NEW_URL = "foo-prismic-url-3";
@@ -201,7 +203,8 @@ describe("Prismic", () => {
 
     it("should override previously defined url when using providers handler even when provider has its own prismic tag defined", async () => {
       expect.assertions(1);
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         tags: ["prismic"],
       });
       const FOO_NEW_URL = "foo-prismic-url-3";
@@ -214,7 +217,8 @@ describe("Prismic", () => {
 
     it("should work when using providers handler even when provider has its own tags defined", async () => {
       expect.assertions(1);
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         tags: ["foo-tag", "foo-tag-2"],
       });
       const FOO_NEW_URL = "foo-prismic-url-4";
@@ -227,7 +231,8 @@ describe("Prismic", () => {
 
     it("should work when using providers handler and specific tags", async () => {
       expect.assertions(1);
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         tags: ["foo-tag"],
       });
       const FOO_NEW_URL = "foo-prismic-url-5";
@@ -240,7 +245,8 @@ describe("Prismic", () => {
 
     it("should work when using providers handler and an specific tag that is present in defined tags", async () => {
       expect.assertions(1);
-      prismic = new Prismic(fooPrismicUrl, {
+      prismic = new Prismic({
+        url: fooPrismicUrl,
         tags: ["foo-tag", "foo-tag-3"],
       });
       const FOO_NEW_URL = "foo-prismic-url-5";


### PR DESCRIPTION
### Added
- chore: Add data-provider addons recommended tags to package.json

### Changed
- docs: Adapt docs to data-provider v3 API
- chore(deps): Update dependencies

### Fixed
- feat: Add force option when cleaning cache if url is changed

### BREAKING CHANGES
- feat: Url now has to be defined as a property options object. Options has to be passed as first and unique argument.
- feat: Remove v2 compatibility
